### PR TITLE
Oag 58 duplicate code bug

### DIFF
--- a/src/OagBundle/Controller/ActivityController.php
+++ b/src/OagBundle/Controller/ActivityController.php
@@ -129,6 +129,12 @@ class ActivityController extends Controller
             foreach ($toAddIds as $sectorId) {
                 $sugSector = $sugSectorRepo->findOneById($sectorId);
                 $sector = $sugSector->getSector();
+
+                if (in_array($sector, $toAdd)) {
+                    // no duplicates please
+                    continue;
+                }
+
                 $toAdd[] = $sector;
 
                 $code = $sector->getCode();


### PR DESCRIPTION
> When a code is suggested by multiple sources (e.g. multiple enhancing documents) and the user selects to insert both, there is a database error as creating the association between the resulting Change entity and Code entity twice is not valid under the schema.
> 
> To reproduce, find an IATI Document that has code suggestions that are identical and attempt to add them both.

This pull request fixes that bug.