### PR TITLE
Added a call to the classifier service

### DIFF
--- a/app/config/oag.yml
+++ b/app/config/oag.yml
@@ -16,6 +16,7 @@ parameters:
     classifier:
         vocabulary: '99'
         vocabulary_uri: 'http://gis.foundationcenter.org/OpenAgCoder/'
+        endpoint: 'https://gis.foundationcenter.org/ag-classify/predict.php'
     geocoder:
         id_vocabulary: 'G1'
         admin_1_vocabulary: 'PLACEHOLDER'

--- a/src/OagBundle/Resources/views/OagFile/classifyText.html.twig
+++ b/src/OagBundle/Resources/views/OagFile/classifyText.html.twig
@@ -7,7 +7,7 @@
 {% block body %}
     {% if sectors|length > 0 %}
         <h2>Sectors</h2>
-        {{ include('OagBundle::OagFile/sectors_table.html.twig', { 'sectors': sectors }) }}
+        {{ include('OagBundle::OagFile/suggested_sectors_table.html.twig', { 'sectors': sectors }) }}
     {% else %}
         <h2>No sectors associated</h2>
     {% endif %}

--- a/src/OagBundle/Resources/views/OagFile/classifyXml.html.twig
+++ b/src/OagBundle/Resources/views/OagFile/classifyXml.html.twig
@@ -6,11 +6,9 @@
 
 {% block body %}
     {% if sectors|length > 0 %}
-        {% for part in sectors %}
-            {% for activityId, activitySectors in part %}
-                <h2>{{ activityId }}</h2>
-                {{ include('OagBundle::OagFile/sectors_table.html.twig', { 'sectors': activitySectors }) }}
-            {% endfor %}
+        {% for activityId, activitySectors in sectors|formatSectorList %}
+            <h2>{{ activityId }}</h2>
+            {{ include('OagBundle::OagFile/suggested_sectors_table.html.twig', { 'sectors': activitySectors }) }}
         {% endfor %}
     {% else %}
         <h2>No sectors associated</h2>

--- a/src/OagBundle/Resources/views/OagFile/enhancement.html.twig
+++ b/src/OagBundle/Resources/views/OagFile/enhancement.html.twig
@@ -8,7 +8,7 @@
     <h2>Mime type: {{ mimetype }}</h2>
 
     {% if sectors|length > 0 %}
-        {{ include('OagBundle::OagFile/sectors_table.html.twig', { 'sectors': sectors }) }}
+        {{ include('OagBundle::OagFile/suggested_sectors_table.html.twig', { 'sectors': sectors }) }}
     {% else %}
         <h2>No sectors associated</h2>
     {% endif %}

--- a/src/OagBundle/Resources/views/OagFile/iati.html.twig
+++ b/src/OagBundle/Resources/views/OagFile/iati.html.twig
@@ -8,6 +8,8 @@
     {{ parent() }}
     |
     <a class='view-xml-link' href="{{ asset('xml')}}/{{ oagfiles_dir }}/{{ name }}">Raw XML</a>
+    |
+    <a class='view-xml-link' href="{{ path('oag_oagfile_classifyxml', { 'id': id }) }}">Re-Classify</a>
 {% endblock %}
 
 {% block body %}

--- a/src/OagBundle/Resources/views/OagFile/sector_row.html.twig
+++ b/src/OagBundle/Resources/views/OagFile/sector_row.html.twig
@@ -1,0 +1,2 @@
+<td>{{ sector.code }}</td>
+<td>{{ sector.description }}</td>

--- a/src/OagBundle/Resources/views/OagFile/suggested_sectors_table.html.twig
+++ b/src/OagBundle/Resources/views/OagFile/suggested_sectors_table.html.twig
@@ -3,12 +3,14 @@
         <tr>
             <th>AGROVOC Code</th>
             <th>Description</th>
+            <th>Confidence</th>
         </tr>
     </thead>
     <tbody>
         {% for sector in sectors %}
             <tr>
-                {{ include('OagBundle::OagFile/sector_row.html.twig', { 'sector': sector }) }}
+                {{ include('OagBundle::OagFile/sector_row.html.twig', { 'sector': sector.sector }) }}
+                <td>{{ sector.confidence }}</td>
             </tr>
         {% endfor %}
     </tbody>

--- a/src/OagBundle/Twig/OagExtension.php
+++ b/src/OagBundle/Twig/OagExtension.php
@@ -50,6 +50,7 @@ class OagExtension extends \Twig_Extension {
         return array(
             new \Twig_SimpleFilter('isCoveable', array($this, 'isCoveable')),
             new \Twig_SimpleFilter('isClassifiable', array($this, 'isClassifiable')),
+            new \Twig_SimpleFilter('formatSectorList', array($this, 'formatSectors')),
         );
     }
 
@@ -73,4 +74,12 @@ class OagExtension extends \Twig_Extension {
         return false;
     }
 
+    public function formatSectors($sectors) {
+        return array_reduce($sectors, function($reduction, $sector) {
+            $activityList = &$reduction[$sector->getActivityId()];
+            if(!$activityList) $activityList = [];
+            array_push($activityList, $sector);
+            return $reduction;
+        }, []);
+    }
 }


### PR DESCRIPTION
I fixed up some mess with the templates. We'd started to get into a habit of using the data structures provided by the API in our templates. We then wrote code to format our own structures back into the API structures so we can re-use our templates. This will get worse and harder to unpick if we do this more.

I also added a small helper for pushing an array of sectors into a hierarchy, this is useful for rendering UI where we have sectors grouped by activity id. **We should perhaps consider modelling this relationship at our data layer rather than at the UI... bear in mind the point of the UI in the future will be to pick a suggestion for an activity**

```
oagfile
  ->suggestedSectors
    ->activity
```
```
oagfile
  ->activities
    ->suggestedSectors
```
