### PR TITLE
Edit landing page template, create new page to view stored files

### DIFF
--- a/app/Resources/views/base.html.twig
+++ b/app/Resources/views/base.html.twig
@@ -8,14 +8,14 @@
             <link href="{{ asset('css/main.css') }}" rel="stylesheet" />
         {% endblock %}
     </head>
+
     <body>
+        {# Header and nav #}
         <h1><a href="{{ path('oag_default_index') }}">OAG Toolbox</a></h1>
 
-        <h2>{% block h2 %}Title{% endblock %}</h2>
-
         <div id="menu" style='padding-bottom: 30px'>
-        {% block menu %}{% endblock %}
-    </div>
+            {% block menu %}{% endblock %}
+        </div>
 
         {% for label, messages in app.flashes %}
             {% for message in messages %}
@@ -26,12 +26,12 @@
         {% endfor %}
 
         <div id="content">
-        {% block body %}{% endblock %}
-    </div>
-    <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
-    <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
-    {% block javascripts %}
-        <script src="{{ asset('js/main.js') }}"></script>
-    {% endblock %}
-</body>
+            {% block body %}{% endblock %}
+        </div>
+        <script src="https://code.jquery.com/jquery-1.12.4.js"></script>
+        <script src="https://code.jquery.com/ui/1.12.1/jquery-ui.js"></script>
+        {% block javascripts %}
+            <script src="{{ asset('js/main.js') }}"></script>
+        {% endblock %}
+    </body>
 </html>

--- a/src/OagBundle/Resources/public/sass/main.scss
+++ b/src/OagBundle/Resources/public/sass/main.scss
@@ -1,5 +1,6 @@
-# Install these with
-# php ./bin/console assets:install public --symlink --relative
+// Install these with
+// php ./bin/console assets:install public --symlink --relative
+
 body {
-    background: #cdcd00;
+    background: #ececec;
 }

--- a/src/OagBundle/Resources/public/stylesheets/main.css
+++ b/src/OagBundle/Resources/public/stylesheets/main.css
@@ -1,4 +1,4 @@
-/* line 1, ../sass/main.scss */
+/* line 4, ../sass/main.scss */
 body {
-  background: #cdcd00;
+  background: #ececec;
 }

--- a/src/OagBundle/Resources/views/Default/index.html.twig
+++ b/src/OagBundle/Resources/views/Default/index.html.twig
@@ -1,4 +1,4 @@
-{# This inherrites from /app/Resources/views/base.html.twig #}
+{# This inherits from /app/Resources/views/base.html.twig #}
 {% extends 'base.html.twig' %}
 
 {% block stylesheets %}
@@ -9,77 +9,38 @@
 
 {% block title %}Tool POCs{% endblock %}
 
-{% block h2 %}Open Ag Toolbox{% endblock %}
-
 {% block body %}
 
-    <h2>IATI Documents</h2>
+    <h2>Using the Open Ag Toolbox you can:</h2>
 
-    <ul>
-        {% for iatidoc in iatidocs %}
-            <li>
-                <a href="{{ path('oag_dportal_oagfile', { 'id': iatidoc.id }) }}" target="dportal">[Visualise]</a>
-                {{ include('OagBundle::Default/iatiFile.html.twig', { 'iatiDoc': iatidoc }) }}
-                <ul>
-                    {% for enhancingDoc in iatidoc.enhancingDocuments %}
-                        <li>
-                            {{ include('OagBundle::Default/enhancementFile.html.twig', { 'enhancingDoc': enhancingDoc }) }}
-                        </li>
-                    {% endfor %}
-                </ul>
-            </li>
-        {% endfor %}
-    </ul>
+    <h3>View - How your data will look to the world.</h3>
 
-    <h2>Unvalidated IATI Documents</h2>
+    <h3>Check - What your data can be used for and improve it.</h3>
 
-    <ul>
-        {% for sourceDoc in sourceDocs %}
-            <li>
-                {{ include('OagBundle::Default/sourceFile.html.twig', { 'sourceDoc': sourceDoc }) }}
-            </li>
-        {% endfor %}
-        <div class="upload-form">
-            <h3>Import a new source document</h3>
-            <div>The imported document will be automatically processed with CoVE and added to the IATI document list above.</div>
-            <div>Currently only XML is supported.</div>
-            <div>
-                {{ form_start(source_upload_form) }}
-                {{ form_label(source_upload_form.documentName) }}
-                {{ form_errors(source_upload_form.documentName) }}
-                {{ form_widget(source_upload_form.documentName) }}
+    <h3>Publish - Your improved activity file.</h3>
 
-                {{ form_widget(source_upload_form.fileType, { 'attr': {'class': 'hidden-row'} }) }}
-                {{ form_end(source_upload_form) }}
-            </div>
+    <h2>Get Started:</h2>
+
+    <div class="upload-form">
+        <h3>Import a new source document</h3>
+        <div>The imported document will be automatically processed with CoVE and added to the IATI document list above.</div>
+        <div>Currently only XML is supported.</div>
+        <div>
+            {{ form_start(source_upload_form) }}
+            {{ form_label(source_upload_form.documentName) }}
+            {{ form_errors(source_upload_form.documentName) }}
+            {{ form_widget(source_upload_form.documentName) }}
+
+            {{ form_widget(source_upload_form.fileType, { 'attr': {'class': 'hidden-row'} }) }}
+            {{ form_end(source_upload_form) }}
         </div>
-    </ul>
+    </div>
 
-    <h2>Enhancement Documents <small><small>[activities/locations]</small></small></h2>
+    <h3>What can I upload:</h3>
 
     <ul>
-        {% for enhancingDoc in enhancingDocs %}
-            <li>
-                {{ include('OagBundle::Default/enhancementFile.html.twig', { 'enhancingDoc': enhancingDoc }) }}
-            </li>
-        {% endfor %}
+        <li>A spreadsheet with the right columns.</li>
+        <li>XML that is IATI compliant - see instructions</li>
     </ul>
 
-        <h2>Todo Add</h2>
-        <ul><li>Delete button</li></ul>
-
-{% endblock %}
-
-{% block javascripts %}
-    <script type="text/javascript" src="{{ asset('bundles/oag/js/main.js') }}"></script>
-    <script>
-        $(function () {
-            $(document).tooltip();
-
-            $("#select-all-delete").click(function () {
-                var checkBoxes = $(".cbox-del");
-                checkBoxes.prop("checked", !checkBoxes.prop("checked"));
-            });
-        });
-    </script>
 {% endblock %}

--- a/src/OagBundle/Resources/views/Default/storedFiles.html.twig
+++ b/src/OagBundle/Resources/views/Default/storedFiles.html.twig
@@ -1,0 +1,85 @@
+{# This inherrites from /app/Resources/views/base.html.twig #}
+{% extends 'base.html.twig' %}
+
+{% block stylesheets %}
+    <link rel="stylesheet" href="https://unpkg.com/purecss@1.0.0/build/pure-min.css" integrity="sha384-nn4HPE8lTHyVtfCBi5yW9d20FjT8BJwUXyWZT9InLYax14RDjBj46LmSztkmNP9w" crossorigin="anonymous">
+    <link href="{{ asset('bundles/oag/css/main.css') }}" rel="stylesheet" />
+    <link href="{{ asset('bundles/oag/stylesheets/main.css') }}" rel="stylesheet" />
+{% endblock %}
+
+{% block title %}Tool POCs{% endblock %}
+
+{% block h2 %}Open Ag Toolbox{% endblock %}
+
+{% block body %}
+
+    <h2>IATI Documents</h2>
+
+    <ul>
+        {% for iatidoc in iatidocs %}
+            <li>
+                <a href="{{ path('oag_dportal_oagfile', { 'id': iatidoc.id }) }}" target="dportal">[Visualise]</a>
+                {{ include('OagBundle::Default/iatiFile.html.twig', { 'iatiDoc': iatidoc }) }}
+                <ul>
+                    {% for enhancingDoc in iatidoc.enhancingDocuments %}
+                        <li>
+                            {{ include('OagBundle::Default/enhancementFile.html.twig', { 'enhancingDoc': enhancingDoc }) }}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </li>
+        {% endfor %}
+    </ul>
+
+    <h2>Unvalidated IATI Documents</h2>
+
+    <ul>
+        {% for sourceDoc in sourceDocs %}
+            <li>
+                {{ include('OagBundle::Default/sourceFile.html.twig', { 'sourceDoc': sourceDoc }) }}
+            </li>
+        {% endfor %}
+        <div class="upload-form">
+            <h3>Import a new source document</h3>
+            <div>The imported document will be automatically processed with CoVE and added to the IATI document list above.</div>
+            <div>Currently only XML is supported.</div>
+            <div>
+                {{ form_start(source_upload_form) }}
+                {{ form_label(source_upload_form.documentName) }}
+                {{ form_errors(source_upload_form.documentName) }}
+                {{ form_widget(source_upload_form.documentName) }}
+
+                {{ form_widget(source_upload_form.fileType, { 'attr': {'class': 'hidden-row'} }) }}
+                {{ form_end(source_upload_form) }}
+            </div>
+        </div>
+    </ul>
+
+    <h2>Enhancement Documents <small><small>[activities/locations]</small></small></h2>
+
+    <ul>
+        {% for enhancingDoc in enhancingDocs %}
+            <li>
+                {{ include('OagBundle::Default/enhancementFile.html.twig', { 'enhancingDoc': enhancingDoc }) }}
+            </li>
+        {% endfor %}
+    </ul>
+
+        <h2>Todo Add</h2>
+        <ul><li>Delete button</li></ul>
+
+{% endblock %}
+
+{% block javascripts %}
+    <script type="text/javascript" src="{{ asset('bundles/oag/js/main.js') }}"></script>
+    <script>
+        $(function () {
+            $(document).tooltip();
+
+            $("#select-all-delete").click(function () {
+                var checkBoxes = $(".cbox-del");
+                checkBoxes.prop("checked", !checkBoxes.prop("checked"));
+            });
+        });
+    </script>
+{% endblock %}


### PR DESCRIPTION
I've moved some of the markup from index.html.twig to a new file called storedFiles.html.twig. This is where any uploaded files will display, and where the user should be redirected to after a successful file upload after clicking 'Upload'.

The index.html.twig page should just be a starting point and should not show and previously uploaded files.

Currently the user remains on the index page after a successful file upload, but I need them to be redirected to the new storedFiles.html.twig page so some guidance on creating a new route to this page would be good!