### PR TITLE
Disable buttons on check and improve page

### DIFF
--- a/src/OagBundle/Resources/public/sass/main.scss
+++ b/src/OagBundle/Resources/public/sass/main.scss
@@ -99,6 +99,15 @@ button,
   &.back:hover {
     color: $oag_dark;
   }
+  &:disabled {
+    background-color: grey;
+    cursor: pointer;
+    transform: none;
+    box-shadow: none;
+    &:hover {
+      box-shadow: none;
+    }
+  }
 }
 
 .view:before {

--- a/src/OagBundle/Resources/views/Wireframe/improveYourData.html.twig
+++ b/src/OagBundle/Resources/views/Wireframe/improveYourData.html.twig
@@ -21,12 +21,10 @@
                             {% for filename in status.classifier.filenames %}
                         <li class='status-file'>{{ filename }}</li>
                             {% endfor %}
-                        <li class='status-file'>salt.xml</li>
-                        <li class='status-file'>pepper.xml</li>
                     </ul>
                 </div>
             </article>
-                    
+
             <article class="activity" id="geocoder-status" data-statusurl="{{ geocoderUrl }}">
                 <div class="heading summary improve">
                     <h2>Geocoding</h2>
@@ -39,7 +37,7 @@
                     </ul>
                 </div>
             </article>
-               
+
             <div class="intro margin">
                 <h1>Check and improve your data</h1>
             </div>
@@ -83,7 +81,7 @@
                 </div>
             </article>
 
-     
+
             {% if (not geocoded) or (not classified) %}
             <article class="activity">
                 <div class="heading summary improve">
@@ -142,10 +140,11 @@
         $( document ).ready(function() {
             checkStatus('#classifer-status');
             checkStatus('#geocoder-status');
-            
+
             function checkStatus(selectortext) {
                 var url = $(selectortext).data('statusurl');
                 var items = [];
+                $('button').prop("disabled", true);
                 $(selectortext + ' .status-file').each(function (key, ele){
                     items.push($(ele).text());
                 });
@@ -159,20 +158,21 @@
                     $.each(to_add, function(key, value) {
                         $(selectortext + ' ul').append('<li class="status-file">' + value + '</li>');
                     });
-                    
+
                     if (data.filenames.length === 0) {
                         $(selectortext).slideUp();
+                      //  $('button').prop("disabled", false);
                     }
                     else {
                         $(selectortext).slideDown();
                     }
-                    
+
                     setTimeout(function() {
                         checkStatus(selectortext);
                     }, 5000);
                 });
             }
-            
+
         });
     </script>
 {% endblock %}


### PR DESCRIPTION
I've not done much here except added CSS for the disabled buttons, and have made them disabled by default on the check and improve page.

I don't know what I'm doing wrong but I can't seem to successfully get the button to remove the disabled attribute after the file has finished processing (see line 164). That commented out line doesn't work - but I don't understand why? If you could take a look that'd be good - I'm in danger of having spent way too much time on what should have been a very quick job. Thanks!